### PR TITLE
Add option to Switch Alt and GUI keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,74 @@
+name: build
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code and install dependencies
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install python3 build-essential gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib libsdl2-dev
+          wget https://github.com/Kitware/CMake/releases/download/v3.31.5/cmake-3.31.5-linux-x86_64.tar.gz
+          tar xf cmake-*-linux-x86_64.tar.gz
+          git submodule update --init --recursive
+          git clone --recursive https://github.com/raspberrypi/pico-sdk
+          wget "https://archive.org/download/Macintosh_ROMs_Collection_1990s/Mac_ROMs.zip/Mac_ROMs%2F68k%2F128k%2FMacintosh%20Plus%2F1986-03%20-%204D1F8172%20-%20MacPlus%20v3.ROM" -O "4D1F8172 - MacPlus v3.ROM"
+          wget "https://archive.org/download/apple-mac-os-system-3.2-finder-5.3-system-tools-1.0-512-ke-jun-1986-3.5-800k.-7z/Apple%20Mac%20OS%20%28System%203.2%20Finder%205.3%29%20%28System%20Tools%201.0%20512Ke%29%20%28Jun%201986%29%20%283.5-800k%29.7z/Apple%20Mac%20OS%20%28System%203.2%20Finder%205.3%29%20%28System%20Tools%201.0%20512Ke%29%20%28Jun%201986%29%20%283.5-800k%29%2FSystem%20Tools%20512ke%20v1.0.img" -O disk.img
+          # Made with: truncate -s 12M disk.img, then copied contents of the disk above and additional content using Mini vMac
+          # wget "https://github.com/probonopd/pico-mac/releases/download/ingredients/disk.zip"
+          # unzip disk.zip
+      - name: Build and upload firmware
+        run: |
+          export PATH=$(readlink -f ./cmake-*-linux-x86_64/bin):$PATH
+          export PICO_SDK_PATH=$(readlink -f ./pico-sdk)
+          for res in "vga" "classic" ; do
+          git submodule foreach git clean -fd
+            cd external/umac/
+            if [ "$res" == "vga" ] ; then
+              echo "Using VGA resolution"
+              make MEMSIZE=208 DISP_WIDTH=640 DISP_HEIGHT=480
+            else
+              echo "Using Classic resolution"
+              make MEMSIZE=208
+            fi
+            cd -
+            ./external/umac/main -r "4D1F8172 - MacPlus v3.ROM" -W rom.bin 2>/dev/null || true
+            ls -lh rom.bin
+            mkdir -p incbin
+            xxd -i < rom.bin > incbin/umac-rom.h
+            xxd -i < disk.img > incbin/umac-disc.h
+  
+            for pin in 18 9; do
+              rm -rf build || true
+              mkdir build
+              cd build
+              if [ "$res" == "vga" ] ; then
+                echo "Using VGA resolution"
+                cmake .. -DMEMSIZE=208 -DUSE_VGA_RES=1 -DVIDEO_PIN=$pin -DUSE_SD=true # -DPICO_BOARD=weact_studio_rp2040_16mb
+              else
+                echo "Using Classic resolution"
+                cmake .. -DMEMSIZE=208 -DVIDEO_PIN=$pin -DUSE_SD=true # -DPICO_BOARD=weact_studio_rp2040_16mb
+              fi
+              make -j$(nproc)
+              cd ..
+              make -C build -j $(nproc)
+              mkdir -p artifacts/pin$pin-$res
+              cp build/firmware.uf2 artifacts/pin$pin-$res/
+            done
+          done
+          ( cd artifacts/ ; zip -r ../firmware.zip * )
+
+      - name: Upload files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          export UPLOADTOOL_SUFFIX=$GITHUB_REF_NAME
+          wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+          bash upload.sh firmware.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,10 @@ jobs:
               cd build
               if [ "$res" == "vga" ] ; then
                 echo "Using VGA resolution"
-                cmake .. -DMEMSIZE=208 -DUSE_VGA_RES=1 -DVIDEO_PIN=$pin -DUSE_SD=true # -DPICO_BOARD=weact_studio_rp2040_16mb
+                cmake .. -DMEMSIZE=208 -DUSE_VGA_RES=1 -DVIDEO_PIN=$pin -DUSE_SD=true -DSWITCH_ALT_GUI=true # -DPICO_BOARD=weact_studio_rp2040_16mb
               else
                 echo "Using Classic resolution"
-                cmake .. -DMEMSIZE=208 -DVIDEO_PIN=$pin -DUSE_SD=true # -DPICO_BOARD=weact_studio_rp2040_16mb
+                cmake .. -DMEMSIZE=208 -DVIDEO_PIN=$pin -DUSE_SD=true -DSWITCH_ALT_GUI=true # -DPICO_BOARD=weact_studio_rp2040_16mb
               fi
               make -j$(nproc)
               cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SD_CS 5 CACHE STRING "SD SPI CS pin")
 set(SD_MHZ 5 CACHE STRING "SD SPI speed in MHz")
 option(USE_VGA_RES "Video uses VGA (640x480) resolution" OFF)
 set(VIDEO_PIN 18 CACHE STRING "Video GPIO base pin (followed by VS, CLK, HS)")
+option(SWITCH_ALT_GUI "Switch Alt and GUI keys" OFF)
 
 # See below, -DMEMSIZE=<size in KB> will configure umac's memory size,
 # overriding defaults.
@@ -95,6 +96,10 @@ else()
    add_compile_definitions(DISP_HEIGHT=342)
 endif()
 add_compile_definitions(GPIO_VID_BASE=${VIDEO_PIN})
+
+if (SWITCH_ALT_GUI)
+    add_compile_definitions(SWITCH_ALT_GUI=1)
+endif()
 
 if (TARGET tinyusb_device)
   add_executable(firmware

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ higher resolution, to change pin configs, etc.:
      using the option above.
    * `-DVIDEO_PIN=<GPIO pin>`: Move the video output pins; defaults
      to the pinout shown below.
+   * `-DSWITCH_ALT_GUI=true`: Switch Alt and GUI keys.  This is
+     useful to have the Mac Command key mapped to the Alt key,
+     which is next to the spacebar on most PC keyboards.
 
 Tip: `cmake` caches these variables, so if you see weird behaviour
 having built previously and then changed an option, delete the `build`

--- a/src/kbd.c
+++ b/src/kbd.c
@@ -164,12 +164,22 @@ static const uint8_t hid_to_mac[256] = {
         /* [HID_KEY_KEYPAD_EQUAL_SIGN] = MKC_, */
         [HID_KEY_CONTROL_LEFT] = MKC_Control,
         [HID_KEY_SHIFT_LEFT] = MKC_Shift,
+#if SWITCH_ALT_GUI
+        [HID_KEY_ALT_LEFT] = MKC_Command,
+        [HID_KEY_GUI_LEFT] = MKC_Option,
+#else
         [HID_KEY_ALT_LEFT] = MKC_Option,
         [HID_KEY_GUI_LEFT] = MKC_Command,
+#endif
         [HID_KEY_CONTROL_RIGHT] = MKC_Control,
         [HID_KEY_SHIFT_RIGHT] = MKC_Shift,
+#if SWITCH_ALT_GUI
+        [HID_KEY_ALT_RIGHT] = MKC_Command,
+        [HID_KEY_GUI_RIGHT] = MKC_Option,
+#else
         [HID_KEY_ALT_RIGHT] = MKC_Option,
         [HID_KEY_GUI_RIGHT] = MKC_Command,
+#endif
 };
 
 static bool     kbd_map(uint8_t hid_keycode, bool pressed, uint16_t *key_out)


### PR DESCRIPTION
Closes #26, #38.

```
-DSWITCH_ALT_GUI=true: Switch Alt and GUI keys.  This is
     useful to have the Mac Command key mapped to the Alt key,
     which is next to the spacebar on most PC keyboards.
```

Build for testing:

https://github.com/probonopd/pico-mac/releases/tag/continuous-switch_alt_gui